### PR TITLE
Added water.css from NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-firebase-hooks": "^2.2.0",
-    "swr": "^0.2.3"
+    "swr": "^0.2.3",
+    "water.css": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^14.0.23",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,8 @@
 import { AppProps } from 'next/app'
-import Head from 'next/head'
+// import Head from 'next/head'
+
+import 'water.css/out/dark.min.css'
 
 export default ({ Component, pageProps }: AppProps) => <>
-  <Head>
-    <link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/kognise/water.css@latest/dist/dark.min.css' />
-  </Head>
-
   <Component {...pageProps} />
 </>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,4 @@
 import { AppProps } from 'next/app'
-// import Head from 'next/head'
 
 import 'water.css/out/dark.min.css'
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,4 @@ import { AppProps } from 'next/app'
 
 import 'water.css/out/dark.min.css'
 
-export default ({ Component, pageProps }: AppProps) => <>
-  <Component {...pageProps} />
-</>
+export default ({ Component, pageProps }: AppProps) => <Component {...pageProps} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -6544,6 +6544,11 @@ watchpack@^1.6.1:
     chokidar "^3.4.0"
     watchpack-chokidar2 "^2.0.0"
 
+water.css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/water.css/-/water.css-2.0.0.tgz#9d7baa1508a4e7b5ae276ea6b87f80a43b341ac2"
+  integrity sha512-GoogHcpwiQEHktKjwIEyWIoZrvbxUb8KJDOGGZL8dvO+I8F9HYYLbEia5QrllJVd4CFfy5WWaYeXh8RYjh8JdQ==
+
 web-vitals@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.1.tgz#60782fa690243fe35613759a0c26431f57ba7b2d"


### PR DESCRIPTION
I made the **bold** decision to add `water.css` from NPM. This is due to the v2 release, which @kognise knows way more about than I do. 

Anyway, this means that `water.css` can be loaded without another network request.

Resolves no issue, because no-one asked for this